### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/DiscordEmbed.js
+++ b/DiscordEmbed.js
@@ -6,7 +6,7 @@ async function handleRequest(request) {
       const contentType = response.headers.get("content-type");
       if (contentType && contentType.startsWith("image/")) {
         const url = new URL(request.url);
-        const filename = decodeURIComponent(url.pathname.substr(url.pathname.lastIndexOf("/") + 1));
+        const filename = decodeURIComponent(url.pathname.slice(url.pathname.lastIndexOf("/") + 1));
         const title = "ShareX";
         const description = filename;
         const color = "#00aff4";


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.